### PR TITLE
refactor: update changelog generation to use conventional commits format

### DIFF
--- a/.github/workflows/tag-release-and-publish.yml
+++ b/.github/workflows/tag-release-and-publish.yml
@@ -27,13 +27,17 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      # Generate changelog BEFORE bump so it covers commits since last tag
+      # Generate changelog using conventional commits
       - name: Generate changelog text
         id: changelog
-        uses: loopwerk/tag-changelog@v1
+        uses: TriPSs/conventional-changelog-action@v5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          exclude_types: other,perf
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          output-file: CHANGELOG.md
+          skip-version-file: true
+          skip-commit: true
+          skip-tag: true
+          preset: conventionalcommits
 
       # Bump version, commit, and tag in one step
       - name: Determine and bump version


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] My PR title follows the Conventional Commits format (e.g., `feat:`, `fix:`, `chore:`)
- [x] My commits are descriptive and follow the same format
- [x] I have explained the context and reasoning for this change
- [x] I have updated documentation as needed

## Description
Changelog not updating correctly so changing the process of changelog generation.
