### PR TITLE
fix: Update resolve-versions.js to fix issue with versions not resolving

### DIFF
--- a/scripts/resolve-versions.js
+++ b/scripts/resolve-versions.js
@@ -143,8 +143,21 @@ async function resolveVersions() {
 
     printProgress('', true); // newline after final progress
 
-    for (const { pkg, versions } of resolved) {
-      if (!pkg || !versions) continue;
+    for (const item of resolved) {
+      if (!item) {
+        logToRoot('Skipped entry: null or undefined in resolved array.');
+        continue;
+      }
+    
+      const { pkg, versions } = item;
+    
+      if (!pkg || !versions) {
+        logToRoot(
+          `Skipped entry: missing pkg or versions. pkg=${pkg || 'null'}, versions=${versions || 'null'}`
+        );
+        continue;
+      }
+    
       if (!threats[pkg]) threats[pkg] = [];
       const existing = new Set(threats[pkg]);
       for (const v of versions) existing.add(v);


### PR DESCRIPTION
# Pull Request

## Checklist
- [ ] My PR title follows the Conventional Commits format (e.g., `feat:`, `fix:`, `chore:`)
- [ ] My commits are descriptive and follow the same format
- [ ] I have explained the context and reasoning for this change
- [ ] I have updated documentation as needed

## Description
Fixes:

Run npm run update-threats

> scan-compromised@1.1.1 update-threats
> node scripts/fetch-advisories.js && node scripts/resolve-versions.js


Fetching advisories updated since 2025-09-19T00:32:27Z...

Fetching page 1...Fetched 5 packages into data/advisories.json

Error in resolveVersions: TypeError: Cannot destructure property 'pkg' of '.for' as it is null.
    at resolveVersions (file:///home/runner/work/scan-compromised/scan-compromised/scripts/resolve-versions.js:146:18)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
Error: Process completed with exit code 1.
