### PR TITLE
fix: update workflow not creating unique branch name

### DIFF
--- a/.github/workflows/update-threats.yml
+++ b/.github/workflows/update-threats.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Create new branch and commit changes
         id: commit_step
         run: |
-          BRANCH="update-threats-$(date +'%Y%m%d')"
+          BRANCH="update-threats-$(date +'%Y%m%d')-${{ github.run_id }}"
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
           git checkout -b "$BRANCH"


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] My PR title follows the Conventional Commits format (e.g., `feat:`, `fix:`, `chore:`)
- [x] My commits are descriptive and follow the same format
- [x] I have explained the context and reasoning for this change
- [x] I have updated documentation as needed

## Description
Existing workflow does not create unique branch name meaning multiple runs cannot occur safely on the same day.